### PR TITLE
bug when sending message length

### DIFF
--- a/src/main/java/it/sauronsoftware/junique/Message.java
+++ b/src/main/java/it/sauronsoftware/junique/Message.java
@@ -82,14 +82,14 @@ class Message {
 			outputStream.write(0);
 			outputStream.flush();
 		} else {
+			// Message block.
+			byte[] b = message.getBytes("UTF-8");
 			// Message length.
-			int length = message.length();
+			int length = b.length;
 			// The length block.
 			byte[] lenght = intToByteArray(length);
 			outputStream.write(lenght);
 			outputStream.flush();
-			// Message block.
-			byte[] b = message.getBytes("UTF-8");
 			outputStream.write(b);
 			outputStream.flush();
 		}


### PR DESCRIPTION
String.length() is not the same as String.getBytes("UTF-8").length

When the message includes some multibyte characters the previous code breaks the message.